### PR TITLE
Add contextual hotspot creation menu

### DIFF
--- a/js/app.css
+++ b/js/app.css
@@ -199,3 +199,70 @@ html, body {
   border-radius: 0.375rem;
   padding: 0.25rem 0.5rem;
 }
+
+/* --------- Hotspot Context Menu --------- */
+#hotspotMenu {
+  position: absolute;
+  z-index: 40;
+  background: rgba(17, 24, 39, 0.95);
+  border: 1px solid var(--c-border);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  min-width: 200px;
+  color: var(--c-fg);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+#hotspotMenu .hotspot-menu-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+#hotspotMenu .hotspot-menu-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+#hotspotMenu .hotspot-menu-actions .hotspot-menu-button {
+  flex: 1;
+}
+#hotspotMenu .hotspot-menu-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+#hotspotMenu button {
+  padding: 0.4rem 0.7rem;
+  border-radius: 0.375rem;
+  border: none;
+  background: var(--c-primary);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease-in-out, transform 0.1s ease-in-out;
+}
+#hotspotMenu button:hover {
+  background: var(--c-primary-hover);
+}
+#hotspotMenu button:active {
+  transform: scale(0.98);
+}
+#hotspotMenu .hotspot-menu-confirm {
+  align-self: flex-end;
+}
+#hotspotMenu select,
+#hotspotMenu textarea {
+  width: 100%;
+  background: var(--c-bg);
+  color: var(--c-fg);
+  border: 1px solid var(--c-border);
+  border-radius: 0.375rem;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.875rem;
+}
+#hotspotMenu textarea {
+  min-height: 90px;
+  resize: vertical;
+}


### PR DESCRIPTION
## Summary
- replace the prompt workflow on double click with a contextual hotspot menu inside the viewer
- support selecting destination scenes or entering info text from the menu before creating the hotspot
- add styling for the hotspot context menu and its form controls

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68c910dedcb48322a142aa37305ccca5