### PR TITLE
Ensure new hotspots receive editors

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -363,7 +363,11 @@ function addHotspot(sceneId, hotspot) {
   scene.hotSpots ||= [];
   scene.hotSpots.push(hotspot);
   viewer.addHotSpot(hotspot, sceneId);
-  if (hotspot.div) enableDrag(hotspot.div, hotspot, sceneId);
+  if (hotspot.div) {
+    enableDrag(hotspot.div, hotspot, sceneId);
+  }
+  attachHotspotEditors();
+  if (!hotspot.div) setTimeout(attachHotspotEditors, 0);
   scheduleAutoSave();
 }
 


### PR DESCRIPTION
## Summary
- always re-attach hotspot editors after creating a new hotspot so it gains drag and edit listeners
- defer attaching when the viewer hasn't yet generated the hotspot element

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c946e0ff8c83228192390baa8d9780