### PR TITLE
Add hotspot editing toggle to toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,13 @@
       <div id="hotspotToolbar">
         <button id="addLinkBtn" class="btn icon-link">Añadir enlace</button>
         <button id="addInfoBtn" class="btn icon-info">Añadir info</button>
+        <div class="edit-toggle">
+          <span class="text-xs">Editar</span>
+          <label class="switch">
+            <input type="checkbox" id="hotspotEditToggle" checked>
+            <span class="slider"></span>
+          </label>
+        </div>
       </div>
     </main>
 

--- a/js/app.css
+++ b/js/app.css
@@ -200,6 +200,54 @@ html, body {
   padding: 0.25rem 0.5rem;
 }
 
+#hotspotToolbar .edit-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--c-fg);
+}
+
+#hotspotToolbar .switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+#hotspotToolbar .switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+#hotspotToolbar .slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--c-border);
+  transition: 0.2s;
+  border-radius: 20px;
+}
+#hotspotToolbar .slider:before {
+  position: absolute;
+  content: '';
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #ffffff;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+#hotspotToolbar .switch input:checked + .slider {
+  background-color: var(--c-primary);
+}
+#hotspotToolbar .switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
 /* --------- Hotspot Context Menu --------- */
 #hotspotMenu {
   position: absolute;

--- a/js/app.js
+++ b/js/app.js
@@ -213,7 +213,18 @@ const dom = {
   addLinkBtn:  document.getElementById('addLinkBtn'),
   addInfoBtn:  document.getElementById('addInfoBtn'),
   hotspotToolbar: document.getElementById('hotspotToolbar'),
+  hotspotEditToggle: /** @type {HTMLInputElement} */ (document.getElementById('hotspotEditToggle')),
 };
+
+dom.hotspotEditToggle.addEventListener('change', () => {
+  if (!viewer) return;
+  if (dom.hotspotEditToggle.checked) {
+    attachHotspotEditors();
+  } else {
+    const sceneId = viewer.getScene();
+    viewer.loadScene(sceneId, viewer.getPitch(), viewer.getYaw(), viewer.getHfov());
+  }
+});
 
 function closeHotspotMenu() {
   if (!activeHotspotMenu) return;
@@ -277,12 +288,12 @@ function buildViewer() {
   dblClickHandler = handleViewerDoubleClick;
   dom.panorama.addEventListener('dblclick', dblClickHandler);
 
-  // cuando se cambie de escena volvemos a habilitar drag / editar
+  // cuando se cambie de escena desactivamos la edición
   viewer.on('scenechange', () => {
     closeHotspotMenu();
-    attachHotspotEditors();
+    dom.hotspotEditToggle.checked = false;
   });
-  attachHotspotEditors(); // para la primera escena
+  if (dom.hotspotEditToggle.checked) attachHotspotEditors();
 }
 
 /* ─────────────────────────── HOTSPOT DRAG & EDIT ───────────────────────── */
@@ -323,6 +334,7 @@ function enableDrag(div, hotspot, sceneId) {
 }
 
 function attachHotspotEditors() {
+  if (!dom.hotspotEditToggle.checked) return;
   const sceneId = viewer.getScene();
   const scene = project.scenes[sceneId];
   if (!scene?.hotSpots) return;
@@ -373,7 +385,7 @@ function addHotspot(sceneId, hotspot) {
 
 /* doble‑clic dentro visor */
 function handleViewerDoubleClick(e) {
-  if (!viewer) return;
+  if (!viewer || !dom.hotspotEditToggle.checked) return;
   const coords = viewer.mouseEventToCoords(e);
   if (!coords) return;
   const [pitch, yaw] = coords;
@@ -546,7 +558,7 @@ function startPlacement(placeFn) {
 }
 
 dom.addLinkBtn.addEventListener('click', () => {
-  if (!viewer) return;
+  if (!viewer || !dom.hotspotEditToggle.checked) return;
   const scenes = Object.entries(project.scenes);
   if (scenes.length === 0) return alert('No hay escenas disponibles');
   const menu = document.createElement('select');
@@ -583,7 +595,7 @@ dom.addLinkBtn.addEventListener('click', () => {
 });
 
 dom.addInfoBtn.addEventListener('click', () => {
-  if (!viewer) return;
+  if (!viewer || !dom.hotspotEditToggle.checked) return;
   const infoText = prompt('Texto informativo:');
   if (!infoText) return;
   startPlacement(([pitch, yaw]) => {


### PR DESCRIPTION
## Summary
- Add switch in hotspot toolbar to toggle hotspot edit mode
- Style new switch and hook viewer logic so editing is disabled on scene change and re-enabled via toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c948e766a08322aa5c2ccb303264e1