### PR TITLE
Adjust hotspot deletion refresh sequence

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -361,10 +361,11 @@ function editHotspot(hs, sceneId, event) {
       return;
     }
     const targetId = hs.id;
+    viewer.removeHotSpot(targetId);
     scene.hotSpots = scene.hotSpots.filter((h) => h.id !== targetId);
-    viewer.removeHotSpot(targetId, sceneId);
-    scheduleAutoSave();
+    attachHotspotEditors();
     closeHotspotMenu();
+    scheduleAutoSave();
   };
 
   const showEditForm = () => {


### PR DESCRIPTION
## Summary
- remove the hotspot from the viewer before updating the scene's hotspot list
- refresh hotspot editor bindings after deletion and keep autosave scheduling at the end

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9525b895c8322b495d28d4f181937