### PR TITLE
Adjust hotspot deletion refresh sequence

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -326,12 +326,15 @@ function enableDrag(div, hotspot, sceneId) {
     document.addEventListener('mouseup', onUp);
   });
 
-  // Context‑menu para editar JSON del hotspot
-  div.addEventListener('contextmenu', (e) => {
+  // Doble clic o context‑menu para editar / eliminar el hotspot
+  const openEditor = (e) => {
     e.preventDefault();
     e.stopPropagation();
     editHotspot(hotspot, sceneId, e);
-  });
+  };
+
+  div.addEventListener('contextmenu', openEditor);
+  div.addEventListener('dblclick', openEditor);
 }
 
 function attachHotspotEditors() {
@@ -361,10 +364,15 @@ function editHotspot(hs, sceneId, event) {
       return;
     }
     const targetId = hs.id;
+    if (targetId && hs.div) {
+      try {
+        viewer.removeHotSpot(targetId, sceneId);
+      } catch {}
+    }
     scene.hotSpots = scene.hotSpots.filter((h) => h.id !== targetId);
-    viewer.removeHotSpot(targetId, sceneId);
-    scheduleAutoSave();
+    attachHotspotEditors();
     closeHotspotMenu();
+    scheduleAutoSave();
   };
 
   const showEditForm = () => {
@@ -395,9 +403,12 @@ function editHotspot(hs, sceneId, event) {
         return;
       }
 
-      const previousId = hs.id;
+      if (hs.id && hs.div) {
+        try {
+          viewer.removeHotSpot(hs.id, sceneId);
+        } catch {}
+      }
       Object.assign(hs, parsed);
-      viewer.removeHotSpot(previousId, sceneId);
       viewer.addHotSpot(hs, sceneId);
       attachHotspotEditors();
       scheduleAutoSave();


### PR DESCRIPTION
## Summary
- remove the hotspot from the viewer before updating the scene's hotspot list
- refresh hotspot editor bindings after deletion and keep autosave scheduling at the end
- guard hotspot removal when the DOM element is missing and allow double-click to open the hotspot editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c9525b895c8322b495d28d4f181937