### PR TITLE
Fix hotspot deletion to use scene-scoped removal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -361,8 +361,11 @@ function editHotspot(hs, sceneId, event) {
       return;
     }
     const targetId = hs.id;
-    viewer.removeHotSpot(targetId);
-    scene.hotSpots = scene.hotSpots.filter((h) => h.id !== targetId);
+    viewer.removeHotSpot(targetId, sceneId);
+    const index = scene.hotSpots.findIndex((h) => h.id === targetId);
+    if (index !== -1) {
+      scene.hotSpots.splice(index, 1);
+    }
     attachHotspotEditors();
     closeHotspotMenu();
     scheduleAutoSave();


### PR DESCRIPTION
## Summary
- ensure hotspot deletions specify the scene so pannellum removes the correct node
- mutate the existing hotspots array instead of reassigning to keep viewer references valid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9586460248322a6155b28022eca86