### PR TITLE
Fix hotspot re-creation order during edits

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -399,9 +399,8 @@ function editHotspot(hs, sceneId, event) {
         return;
       }
 
-      const previousId = hs.id;
+      viewer.removeHotSpot(hs.id, sceneId);
       Object.assign(hs, parsed);
-      viewer.removeHotSpot(previousId, sceneId);
       viewer.addHotSpot(hs, sceneId);
       attachHotspotEditors();
       scheduleAutoSave();


### PR DESCRIPTION
## Summary
- remove hotspots before mutating their data in the edit confirmation flow
- re-add hotspots after applying JSON changes to ensure ID updates work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c959c087008322a957f29c58cb90b5