### PR TITLE
Replace open file input with dynamic project opener

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,15 +24,7 @@
 
       <nav class="flex items-center gap-2 text-sm font-medium">
         <button id="newProjectBtn" class="btn">Nuevo</button>
-
-        <!-- "Abrir" usa un <input type=file> oculto para cargar JSON -->
-        <label for="openFileInput" class="btn cursor-pointer">Abrir</label>
-        <input
-          type="file"
-          id="openFileInput"
-          accept="application/json"
-          class="hidden"
-        />
+        <button id="openProjectBtn" class="btn">Abrir</button>
 
         <button id="saveProjectBtn" class="btn">Guardar</button>
         <button id="exportProjectBtn" class="btn">Exportar</button>


### PR DESCRIPTION
## Summary
- replace the hidden file input in the top bar with an explicit "Abrir" button
- add an `openProject` helper that uses `showOpenFilePicker` when available or a dynamic file input to parse and load JSON projects
- remove the legacy `dom.openInput` wiring in favor of the new button-driven loader

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95f3378d88322a589264af62faf57