### PR TITLE
Add UI trigger for adding scenes

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,13 @@
       <aside
         id="sceneList"
         class="w-64 max-w-[50vw] overflow-y-auto border-r border-gray-700 bg-gray-850/80 backdrop-blur-lg hidden md:block"
-      ></aside>
-
-      <input type="file" id="addSceneInput" accept="image/*" multiple class="hidden">
+      >
+        <div class="scene-list-header">
+          <button id="addSceneBtn" class="btn add-scene-btn">Añadir escena</button>
+          <div class="scene-drop-hint">Arrastra imágenes 360° o usa el botón.</div>
+        </div>
+        <div id="sceneListItems" class="scene-list-items"></div>
+      </aside>
 
       <!-- Contenedor Pannellum -->
       <section id="panorama" class="flex-1 relative"></section>

--- a/js/app.css
+++ b/js/app.css
@@ -75,6 +75,31 @@ html, body {
   overflow-y: auto;
   padding: 1rem;
   box-shadow: inset -2px 0 4px rgba(0,0,0,0.5);
+  gap: 1rem;
+}
+
+#sceneList .scene-list-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+#sceneList .add-scene-btn {
+  width: 100%;
+}
+
+#sceneList .scene-drop-hint {
+  font-size: 0.75rem;
+  text-align: center;
+  color: #9ca3af; /* gray-400 */
+}
+
+#sceneListItems,
+#sceneList .scene-list-items {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 #sceneList .scene-load {
@@ -82,7 +107,6 @@ html, body {
   background: transparent;
   color: inherit;
   width: 100%;
-  margin-bottom: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.375rem;
 }
@@ -107,16 +131,17 @@ html, body {
   color: var(--c-primary);
 }
 
-#sceneList p {
+#sceneList .empty-message {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--c-fg);
+  color: #9ca3af;
   border: 2px dashed var(--c-border);
   border-radius: 0.375rem;
-  margin: 1rem 0;
+  padding: 1rem;
   text-align: center;
+  font-size: 0.875rem;
 }
 
 #sceneList.ring {


### PR DESCRIPTION
## Summary
- add an "Añadir escena" button and drop hint inside the scene list panel
- restyle the sidebar to accommodate the new controls and empty-state message
- replace the hidden file input with `promptSceneFiles()` that uses the button and modern file pickers

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9622a59088322af2a6b43e5d0176d