### PR TITLE
Bundle pannellum dependencies for offline tour exports

### DIFF
--- a/deploy/index.html
+++ b/deploy/index.html
@@ -6,7 +6,7 @@
     <title>Tour Pannellum</title>
 
     <!-- Pannellum core -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.css" />
+    <link rel="stylesheet" href="libs/pannellum.css" />
     <link rel="stylesheet" href="viewer.css" />
 
     <style>
@@ -363,7 +363,7 @@
     </button>
 
     <!-- Librería Pannellum -->
-    <script src="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.js"></script>
+    <script src="libs/pannellum.js"></script>
     <!-- Lógica del visor -->
     <script src="viewer.js"></script>
   </body>

--- a/js/app.js
+++ b/js/app.js
@@ -992,6 +992,31 @@ async function exportProject () {
   zip.file('index.html', indexHtml);
   zip.file('viewer.css', viewerCss);
 
+  const libsFolder = zip.folder('libs');
+  if (!libsFolder) {
+    throw new Error('No se pudo crear la carpeta "libs" en el ZIP');
+  }
+
+  const libsToCopy = [
+    { source: 'libs/pannellum.css', target: 'pannellum.css' },
+    { source: 'libs/pannellum.js', target: 'pannellum.js' },
+  ];
+
+  await Promise.all(
+    libsToCopy.map(async ({ source, target }) => {
+      try {
+        const response = await fetch(source);
+        if (!response.ok) {
+          throw new Error(`Respuesta ${response.status} al obtener ${source}`);
+        }
+        const buffer = await response.arrayBuffer();
+        libsFolder.file(target, buffer);
+      } catch (error) {
+        console.error(`No se pudo copiar la librería ${source} al ZIP`, error);
+      }
+    })
+  );
+
   // ─────────── 2. tour.json ──────────────────
   const tourScenes = {};
   Object.entries(project.scenes).forEach(([id, scene]) => {


### PR DESCRIPTION
## Summary
- update the deploy viewer to load pannellum assets from local libs paths
- include pannellum CSS and JS inside the exported ZIP so the viewer works offline

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca5171677483229741175ce5fa1319