### PR TITLE
Hide default pannellum controls

### DIFF
--- a/deploy/viewer.css
+++ b/deploy/viewer.css
@@ -17,3 +17,10 @@
 .info-hotspot span {
   white-space: nowrap;
 }
+
+/* Hide default Pannellum controls and author box */
+.pnlm-controls-container,
+.pnlm-author-box {
+  display: none !important;
+  visibility: hidden !important;
+}


### PR DESCRIPTION
## Summary
- hide Pannellum's built-in controls and author box in the exported viewer stylesheet to keep the custom UI clean

## Testing
- Manual: Viewed deploy/index.html in the browser to verify that only the custom controls remain visible

------
https://chatgpt.com/codex/tasks/task_e_68ca565055708322963782848b26436a