### PR TITLE
Remove fullscreen button from exported viewer

### DIFF
--- a/deploy/index.html
+++ b/deploy/index.html
@@ -353,14 +353,6 @@
         </svg>
       </button>
     </div>
-    <button class="ctrl fullscreen" id="btnFS" data-tip="Pantalla completa (F)" aria-label="Pantalla completa" disabled>
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-        <path
-          stroke-width="1.8"
-          d="M8 3H4a1 1 0 0 0-1 1v4m0 8v4a1 1 0 0 0 1 1h4m8-18h4a1 1 0 0 1 1 1v4m0 8v4a1 1 0 0 1-1 1h-4"
-        />
-      </svg>
-    </button>
 
     <!-- Librería Pannellum -->
     <script src="libs/pannellum.js"></script>

--- a/deploy/viewer.css
+++ b/deploy/viewer.css
@@ -24,3 +24,7 @@
   display: none !important;
   visibility: hidden !important;
 }
+
+#pano .pnlm-panorama-info {
+  display: none !important;
+}

--- a/deploy/viewer.js
+++ b/deploy/viewer.js
@@ -21,7 +21,7 @@ const dom = {
   roomLabel: /** @type {HTMLSpanElement} */ (document.getElementById('roomLabel')),
   zoomIn: /** @type {HTMLButtonElement} */ (document.getElementById('zoomIn')),
   zoomOut: /** @type {HTMLButtonElement} */ (document.getElementById('zoomOut')),
-  fullscreen: /** @type {HTMLButtonElement} */ (document.getElementById('btnFS')),
+  fullscreen: /** @type {HTMLButtonElement | null} */ (document.getElementById('btnFS')),
 };
 
 const sceneButtons = new Map();

--- a/estiloa.html
+++ b/estiloa.html
@@ -170,9 +170,6 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="2" d="M5 12h14"/></svg>
     </button>
   </div>
-  <button class="ctrl fullscreen" id="btnFS" data-tip="Pantalla completa (F)" aria-label="Pantalla completa">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-width="1.8" d="M8 3H4a1 1 0 0 0-1 1v4m0 8v4a1 1 0 0 0 1 1h4m8-18h4a1 1 0 0 1 1 1v4m0 8v4a1 1 0 0 1-1 1h-4"/></svg>
-  </button>
 
   <script>
     const ROOMS=[

--- a/js/app.css
+++ b/js/app.css
@@ -157,6 +157,11 @@ html, body {
   min-height: 320px;
 }
 
+#panorama .pnlm-panorama-info,
+#pano .pnlm-panorama-info {
+  display: none !important;
+}
+
 /* --------- Ring utility (for dragover highlight) --------- */
 .ring {
   outline: 2px solid var(--ring-color);

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -21,7 +21,7 @@ const dom = {
   roomLabel: /** @type {HTMLSpanElement} */ (document.getElementById('roomLabel')),
   zoomIn: /** @type {HTMLButtonElement} */ (document.getElementById('zoomIn')),
   zoomOut: /** @type {HTMLButtonElement} */ (document.getElementById('zoomOut')),
-  fullscreen: /** @type {HTMLButtonElement} */ (document.getElementById('btnFS')),
+  fullscreen: /** @type {HTMLButtonElement | null} */ (document.getElementById('btnFS')),
 };
 
 const sceneButtons = new Map();


### PR DESCRIPTION
## Summary
- remove the fullscreen control markup from the exported viewer template and legacy mockup
- allow viewer scripts to treat the fullscreen button as optional and hide Pannellum's info overlay in both app and export styles

## Testing
- `zip -r test-tour.zip deploy`


------
https://chatgpt.com/codex/tasks/task_e_68ca63f639208322bc50b95223aeab41