### PR TITLE
Include viewer script in exported ZIP

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -984,13 +984,15 @@ async function exportProject () {
 
   // ─────────── 1. index.html (visor) ─────────
   // Copiamos el visor autónomo desde /deploy/
-  const [indexHtml, viewerCss] = await Promise.all([
+  const [indexHtml, viewerCss, viewerJs] = await Promise.all([
     fetch('deploy/index.html').then(r => r.text()),
     fetch('deploy/viewer.css').then(r => r.text()),
+    fetch('deploy/viewer.js').then(r => r.text()),
   ]);
 
   zip.file('index.html', indexHtml);
   zip.file('viewer.css', viewerCss);
+  zip.file('viewer.js', viewerJs);
 
   const libsFolder = zip.folder('libs');
   if (!libsFolder) {


### PR DESCRIPTION
## Summary
- fetch deploy/viewer.js alongside the existing deploy assets during export
- include viewer.js in the generated ZIP so the standalone viewer has all required files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca65ad8f2883229f7d716d755f763a