### PR TITLE
Ocultar mensaje de carga de Pannellum

### DIFF
--- a/deploy/viewer.css
+++ b/deploy/viewer.css
@@ -28,3 +28,5 @@
 #pano .pnlm-panorama-info {
   display: none !important;
 }
+
+.pnlm-lmsg { display: none !important; }


### PR DESCRIPTION
## Summary
- oculta el mensaje textual del loader de Pannellum en el visor exportado para dejar únicamente la barra de progreso visible

## Testing
- manualmente verifiqué en el navegador que el cuadro de carga solo muestra la barra de progreso y que los mensajes de error siguen visibles

------
https://chatgpt.com/codex/tasks/task_e_68ca6da98dec8322aec029757e06a919