### PR TITLE
Ensure scene orientation persists across loads

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -746,7 +746,12 @@ function renderSceneList() {
     span.textContent = scene.title || id;
     btn.appendChild(span);
 
-    const load = () => viewer?.loadScene(id);
+    const load = () => {
+      if (!viewer) return;
+      const sceneData = project.scenes[id] || {};
+      const { pitch = 0, yaw = 0, hfov = 110 } = sceneData;
+      viewer.loadScene(id, pitch, yaw, hfov);
+    };
     btn.addEventListener('click', load);
     btn.addEventListener('dblclick', load);
 
@@ -768,6 +773,12 @@ function renderSceneList() {
       scene.pitch = pitch;
       scene.yaw = yaw;
       scene.hfov = hfov;
+      const config = viewer.getConfig();
+      if (config?.scenes?.[id]) {
+        config.scenes[id].pitch = pitch;
+        config.scenes[id].yaw = yaw;
+        config.scenes[id].hfov = hfov;
+      }
       scheduleAutoSave();
       viewer.loadScene(id, scene.pitch, scene.yaw, scene.hfov);
       renderSceneList();


### PR DESCRIPTION
## Summary
- pass saved orientation values when loading scenes from the list
- sync pannellum viewer config with newly saved pitch, yaw and hfov values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca91f506f88322b6780803fde8a26f